### PR TITLE
Update author snippet registration

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -13,7 +13,6 @@ from wagtail.admin.panels import (
 from wagtail.fields import RichTextField, StreamField
 from wagtail.models import Page
 from wagtail.search import index
-from wagtail.snippets.models import register_snippet
 
 from home.blocks import StreamBlocks
 from wp_connector.field_panels import WordpressInfoPanel
@@ -35,7 +34,6 @@ class BlogCategory(models.Model):
         verbose_name_plural = "Categories"
 
 
-@register_snippet
 class Author(models.Model):
     name = models.CharField(max_length=255)
     author_image = models.ForeignKey(

--- a/blog/wagtail_hooks.py
+++ b/blog/wagtail_hooks.py
@@ -1,5 +1,6 @@
 from wagtail.snippets.models import register_snippet
 
-from blog.models import BlogCategory
+from blog.models import Author, BlogCategory
 
+register_snippet(Author)
 register_snippet(BlogCategory)


### PR DESCRIPTION
This pull request includes modifications to the `blog` app, specifically focusing on the `Author` model and the registration of snippets. The most important changes involve the relocation of the `register_snippet` decorator and the import statements to ensure proper snippet registration.

### Changes to snippet registration:

* [`blog/models.py`](diffhunk://#diff-62e1768ca8759f6d7a70d12e9823ede27f15fcbbd60718723276fb3891de97deL38): Removed the `register_snippet` decorator from the `Author` model.
* [`blog/wagtail_hooks.py`](diffhunk://#diff-9d538f8d83a044b3e9e4aef185e0938f33537766c1063e47f19d83b08b78e742L3-R5): Added the `register_snippet` decorator for the `Author` model to ensure it is properly registered as a snippet.

### Changes to import statements:

* [`blog/models.py`](diffhunk://#diff-62e1768ca8759f6d7a70d12e9823ede27f15fcbbd60718723276fb3891de97deL16): Removed the import of `register_snippet` from `wagtail.snippets.models` as it is no longer needed in this file.
* [`blog/wagtail_hooks.py`](diffhunk://#diff-9d538f8d83a044b3e9e4aef185e0938f33537766c1063e47f19d83b08b78e742L3-R5): Added the import of the `Author` model to register it as a snippet.