### PR TITLE
Add some user feedback when updating anchor links

### DIFF
--- a/wp_connector/admin.py
+++ b/wp_connector/admin.py
@@ -559,6 +559,8 @@ class BaseAdmin(admin.ModelAdmin):
             richtext_processor = FieldProcessor(obj)
             richtext_processor.process_fields()
 
+        self.handle_message_user(request, "Anchor Links Updated", level="SUCCESS")
+
     def delete_selected(self, admin, request, queryset):
         """
         Delete the selected wordpress objects


### PR DESCRIPTION
This isn't complete but will be covered by other work soon.
This pull request includes a small change to the `wp_connector/admin.py` file. The change adds a success message when anchor links are updated.

* [`wp_connector/admin.py`](diffhunk://#diff-da6545b6f5df96f855217f96f21b657705056e86a83275211ec40f40e59fa3d0R562-R563): Added a success message in the `update_anchor_links` method to notify users when anchor links are successfully updated.